### PR TITLE
allow double quote in escape sequences

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -49,7 +49,7 @@ module.exports = grammar({
 
     escape_sequence: $ => token.immediate(seq(
       '\\',
-      choice('n', 'r', 't', '0', '\\'),
+      choice('n', 'r', 't', '0', '\\', '"'),
     )),
 
     _identifier: $ => /[a-zA-Z0-9_-][a-zA-Z0-9.?!_-]*/,

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -237,6 +237,10 @@
               {
                 "type": "STRING",
                 "value": "\\"
+              },
+              {
+                "type": "STRING",
+                "value": "\""
               }
             ]
           }

--- a/src/parser.c
+++ b/src/parser.c
@@ -59,7 +59,7 @@ enum {
   aux_sym_predicate_repeat1 = 40,
 };
 
-static const char *ts_symbol_names[] = {
+static const char * const ts_symbol_names[] = {
   [ts_builtin_sym_end] = "end",
   [sym__identifier] = "_identifier",
   [sym_comment] = "comment",
@@ -103,7 +103,7 @@ static const char *ts_symbol_names[] = {
   [aux_sym_predicate_repeat1] = "predicate_repeat1",
 };
 
-static TSSymbol ts_symbol_map[] = {
+static const TSSymbol ts_symbol_map[] = {
   [ts_builtin_sym_end] = ts_builtin_sym_end,
   [sym__identifier] = sym__identifier,
   [sym_comment] = sym_comment,
@@ -319,7 +319,7 @@ enum {
   field_quantifier = 2,
 };
 
-static const char *ts_field_names[] = {
+static const char * const ts_field_names[] = {
   [0] = NULL,
   [field_pattern] = "pattern",
   [field_quantifier] = "quantifier",
@@ -346,11 +346,11 @@ static const TSFieldMapEntry ts_field_map_entries[] = {
     {field_quantifier, 2, .inherited = true},
 };
 
-static TSSymbol ts_alias_sequences[PRODUCTION_ID_COUNT][MAX_ALIAS_SEQUENCE_LENGTH] = {
+static const TSSymbol ts_alias_sequences[PRODUCTION_ID_COUNT][MAX_ALIAS_SEQUENCE_LENGTH] = {
   [0] = {0},
 };
 
-static uint16_t ts_non_terminal_alias_map[] = {
+static const uint16_t ts_non_terminal_alias_map[] = {
   0,
 };
 
@@ -404,7 +404,8 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead == ' ') SKIP(2)
       END_STATE();
     case 3:
-      if (lookahead == '0' ||
+      if (lookahead == '"' ||
+          lookahead == '0' ||
           lookahead == '\\' ||
           lookahead == 'n' ||
           lookahead == 'r' ||
@@ -569,7 +570,7 @@ static bool ts_lex_keywords(TSLexer *lexer, TSStateId state) {
   }
 }
 
-static TSLexMode ts_lex_modes[STATE_COUNT] = {
+static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [0] = {.lex_state = 0},
   [1] = {.lex_state = 0},
   [2] = {.lex_state = 0},
@@ -623,7 +624,7 @@ static TSLexMode ts_lex_modes[STATE_COUNT] = {
   [50] = {.lex_state = 0},
 };
 
-static uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
+static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
   [0] = {
     [ts_builtin_sym_end] = ACTIONS(1),
     [sym__identifier] = ACTIONS(1),
@@ -734,7 +735,7 @@ static uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
   },
 };
 
-static uint16_t ts_small_parse_table[] = {
+static const uint16_t ts_small_parse_table[] = {
   [0] = 13,
     ACTIONS(3), 1,
       sym_comment,
@@ -1541,7 +1542,7 @@ static uint16_t ts_small_parse_table[] = {
       ts_builtin_sym_end,
 };
 
-static uint32_t ts_small_parse_table_map[] = {
+static const uint32_t ts_small_parse_table_map[] = {
   [SMALL_STATE(5)] = 0,
   [SMALL_STATE(6)] = 46,
   [SMALL_STATE(7)] = 89,
@@ -1590,7 +1591,7 @@ static uint32_t ts_small_parse_table_map[] = {
   [SMALL_STATE(50)] = 1028,
 };
 
-static TSParseActionEntry ts_parse_actions[] = {
+static const TSParseActionEntry ts_parse_actions[] = {
   [0] = {.entry = {.count = 0, .reusable = false}},
   [1] = {.entry = {.count = 1, .reusable = false}}, RECOVER(),
   [3] = {.entry = {.count = 1, .reusable = true}}, SHIFT_EXTRA(),
@@ -1709,7 +1710,7 @@ extern "C" {
 #endif
 
 extern const TSLanguage *tree_sitter_tsq(void) {
-  static TSLanguage language = {
+  static const TSLanguage language = {
     .version = LANGUAGE_VERSION,
     .symbol_count = SYMBOL_COUNT,
     .alias_count = ALIAS_COUNT,
@@ -1720,18 +1721,18 @@ extern const TSLanguage *tree_sitter_tsq(void) {
     .production_id_count = PRODUCTION_ID_COUNT,
     .field_count = FIELD_COUNT,
     .max_alias_sequence_length = MAX_ALIAS_SEQUENCE_LENGTH,
-    .parse_table = (const uint16_t *)ts_parse_table,
-    .small_parse_table = (const uint16_t *)ts_small_parse_table,
-    .small_parse_table_map = (const uint32_t *)ts_small_parse_table_map,
+    .parse_table = &ts_parse_table[0][0],
+    .small_parse_table = ts_small_parse_table,
+    .small_parse_table_map = ts_small_parse_table_map,
     .parse_actions = ts_parse_actions,
     .symbol_names = ts_symbol_names,
     .field_names = ts_field_names,
-    .field_map_slices = (const TSFieldMapSlice *)ts_field_map_slices,
-    .field_map_entries = (const TSFieldMapEntry *)ts_field_map_entries,
+    .field_map_slices = ts_field_map_slices,
+    .field_map_entries = ts_field_map_entries,
     .symbol_metadata = ts_symbol_metadata,
     .public_symbol_map = ts_symbol_map,
     .alias_map = ts_non_terminal_alias_map,
-    .alias_sequences = (const TSSymbol *)ts_alias_sequences,
+    .alias_sequences = &ts_alias_sequences[0][0],
     .lex_modes = ts_lex_modes,
     .lex_fn = ts_lex,
     .keyword_lex_fn = ts_lex_keywords,

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -102,8 +102,8 @@ struct TSLanguage {
   const uint16_t *small_parse_table;
   const uint32_t *small_parse_table_map;
   const TSParseActionEntry *parse_actions;
-  const char **symbol_names;
-  const char **field_names;
+  const char * const *symbol_names;
+  const char * const *field_names;
   const TSFieldMapSlice *field_map_slices;
   const TSFieldMapEntry *field_map_entries;
   const TSSymbolMetadata *symbol_metadata;
@@ -123,6 +123,7 @@ struct TSLanguage {
     unsigned (*serialize)(void *, char *);
     void (*deserialize)(void *, const char *, unsigned);
   } external_scanner;
+  const TSStateId *primary_state_ids;
 };
 
 /*

--- a/test/corpus/patterns.txt
+++ b/test/corpus/patterns.txt
@@ -554,3 +554,22 @@ Comments
       (child (field_name) pattern: (named_node (node_name)))
       (comment)
       (child (field_name) pattern: (named_node (node_name))))))
+
+==============
+String escapes
+==============
+
+["\"" (attribute_name)] @string
+
+---
+
+(query
+  (pattern
+    pattern: (alternation
+      (choice
+        pattern: (anonymous_leaf
+          (escape_sequence)))
+      (choice
+        pattern: (named_node
+          (node_name))))
+        (capture)))


### PR DESCRIPTION
Hello! 👋

I noticed this edge case in the escape sequences - if you're trying to capture `"` in a query and it isn't a named node you'll need to surround it in quotes but escape it with a backslash. `tree-sitter-cli` accepts that as a valid query but it trips up the parser here.