### PR TITLE
Use `source.` prefix in scope

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "repository": "https://github.com/tree-sitter/tree-sitter-tsq",
   "tree-sitter": [
     {
-      "scope": "scope.tsq",
+      "scope": "source.tsq",
       "file-types": [
         "tsq",
         "scm"


### PR DESCRIPTION
This matches what other implementations do. I'm not sure where this is actually used or what changing it might affect.